### PR TITLE
Best practice fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 env.json
+.idea

--- a/app.js
+++ b/app.js
@@ -26,13 +26,13 @@ class Tweakers extends Homey.App {
 
     //Function LoopTweakers
     async LoopTweakers() {
-        await this.log('Start LoopTweakers');
+        this.log('Start LoopTweakers');
         await this.GetTweakersMixed();
         await this.GetTweakersNieuws();
         await this.GetTweakersMeukTracker();
         await this.GetTweakersGames();
         await this.GetTweakersVraagAanbod();
-        await this.log('Einde LoopTweakers');
+        this.log('Einde LoopTweakers');
     }
 
     //StartLoop
@@ -48,26 +48,26 @@ class Tweakers extends Homey.App {
 
             const url = 'http://feeds.feedburner.com/tweakers/mixed';
 
-            await this.log('Start GetTweakersMixed');
+            this.log('Start GetTweakersMixed');
 
             var items = await feedparser.parse(url);
-            var TweakersMixedTitel = await items[0].title;
-            var TweakersMixedCategorie = await items[0].categories;
-            var TweakersMixedDatumTZ = await items[0].date;
+            var TweakersMixedTitel = items[0].title;
+            var TweakersMixedCategorie = items[0].categories;
+            var TweakersMixedDatumTZ = items[0].date;
             var TweakersMixedDatum = Date.parse(TweakersMixedDatumTZ) / 1000
-            await this.log('End Success GetTweakersMixed');
+            this.log('End Success GetTweakersMixed');
 
         } catch (error) {
             console.error('error: ', error)
-            await this.log('End Error GetTweakersMixed');
+            this.log('End Error GetTweakersMixed');
         }
 
         if (global.TweakersMixed !== TweakersMixedDatum) {
-            await this.log('IF timestamp:', global.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
+            this.log('IF timestamp:', global.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
             global.TweakersMixed = TweakersMixedDatum;
-            await console.log('IF titel:', TweakersMixedTitel);
-            await console.log('IF TweakersMixedCategorie:', TweakersMixedCategorie);
-            await console.log('IF timestamp update:', global.TweakersMixed);
+            console.log('IF titel:', TweakersMixedTitel);
+            console.log('IF TweakersMixedCategorie:', TweakersMixedCategorie);
+            console.log('IF timestamp update:', global.TweakersMixed);
 
             //trigger flow
             let TriggerTweakersMixed = new Homey.FlowCardTrigger('TriggerTweakersMixed');
@@ -83,7 +83,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            await this.log('ELSE timestamp:', global.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
+            this.log('ELSE timestamp:', global.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
         }
 
     }
@@ -95,24 +95,24 @@ class Tweakers extends Homey.App {
 
             const url = 'http://feeds.feedburner.com/tweakers/nieuws';
 
-            await this.log('Start GetTweakersNieuws');
+            this.log('Start GetTweakersNieuws');
 
             var items = await feedparser.parse(url);
-            var TweakersNieuwsTitel = await items[0].title;
-            var TweakersNieuwsDatumTZ = await items[0].date;
+            var TweakersNieuwsTitel = items[0].title;
+            var TweakersNieuwsDatumTZ = items[0].date;
             var TweakersNieuwsDatum = Date.parse(TweakersNieuwsDatumTZ) / 1000
-            await this.log('End Success GetTweakersNieuws');
+            this.log('End Success GetTweakersNieuws');
 
         } catch (error) {
             console.error('error: ', error)
-            await this.log('End Error GetTweakersNieuws');
+            this.log('End Error GetTweakersNieuws');
         }
 
         if (global.TweakersNieuws !== TweakersNieuwsDatum) {
-            await this.log('IF timestamp:', global.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
+            this.log('IF timestamp:', global.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
             global.TweakersNieuws = TweakersNieuwsDatum;
-            await console.log('IF titel:', TweakersNieuwsTitel);
-            await console.log('IF timestamp update:', global.TweakersNieuws);
+            console.log('IF titel:', TweakersNieuwsTitel);
+            console.log('IF timestamp update:', global.TweakersNieuws);
 
             //trigger flow
             let TriggerTweakersNieuws = new Homey.FlowCardTrigger('TriggerTweakersNieuws');
@@ -128,7 +128,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            await this.log('ELSE timestamp:', global.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
+            this.log('ELSE timestamp:', global.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
         }
 
     }
@@ -139,24 +139,24 @@ class Tweakers extends Homey.App {
 
             const url = 'http://feeds.feedburner.com/tweakers/meuktracker';
 
-            await this.log('Start GetTweakersMeukTracker');
+            this.log('Start GetTweakersMeukTracker');
 
             var items = await feedparser.parse(url);
-            var TweakersMeukTitel = await items[0].title;
-            var TweakersMeukDatumTZ = await items[0].date;
+            var TweakersMeukTitel = items[0].title;
+            var TweakersMeukDatumTZ = items[0].date;
             var TweakersMeukDatum = Date.parse(TweakersMeukDatumTZ) / 1000
-            await this.log('End Success GetTweakersMeukTracker');
+            this.log('End Success GetTweakersMeukTracker');
 
         } catch (error) {
             console.error('error: ', error)
-            await this.log('End Error GetTweakersMeukTracker');
+            this.log('End Error GetTweakersMeukTracker');
         }
 
         if (global.TweakersMeukTracker !== TweakersMeukDatum) {
-            await this.log('IF timestamp:', global.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
+            this.log('IF timestamp:', global.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
             global.TweakersMeukTracker = TweakersMeukDatum;
-            await console.log('IF titel:', TweakersMeukTitel);
-            await console.log('IF timestamp update:', global.TweakersMeukTracker);
+            console.log('IF titel:', TweakersMeukTitel);
+            console.log('IF timestamp update:', global.TweakersMeukTracker);
 
             //trigger flow
             let TriggerTweakersMeukTracker = new Homey.FlowCardTrigger('TriggerTweakersMeukTracker');
@@ -172,7 +172,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            await this.log('ELSE timestamp:', global.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
+            this.log('ELSE timestamp:', global.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
         }
 
     }
@@ -183,24 +183,24 @@ class Tweakers extends Homey.App {
 
             const url = 'http://feeds.feedburner.com/tweakers/games';
 
-            await this.log('Start GetTweakersGames');
+            this.log('Start GetTweakersGames');
 
             var items = await feedparser.parse(url);
-            var TweakersGamesTitel = await items[0].title;
-            var TweakersGamesDatumTZ = await items[0].date;
+            var TweakersGamesTitel = items[0].title;
+            var TweakersGamesDatumTZ = items[0].date;
             var TweakersGamesDatum = Date.parse(TweakersGamesDatumTZ) / 1000
-            await this.log('End Success GetTweakersGames');
+            this.log('End Success GetTweakersGames');
 
         } catch (error) {
             console.error('error: ', error)
-            await this.log('End Error GetTweakersGames');
+            this.log('End Error GetTweakersGames');
         }
 
         if (global.TweakersGames !== TweakersGamesDatum) {
-            await this.log('IF timestamp:', global.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
+            this.log('IF timestamp:', global.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
             global.TweakersGames = TweakersGamesDatum;
-            await console.log('IF titel:', TweakersGamesTitel);
-            await console.log('IF timestamp update:', global.TweakersGames);
+            console.log('IF titel:', TweakersGamesTitel);
+            console.log('IF timestamp update:', global.TweakersGames);
 
             //trigger flow
             let TriggerTweakersGames = new Homey.FlowCardTrigger('TriggerTweakersGames');
@@ -216,7 +216,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            await this.log('ELSE timestamp:', global.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
+            this.log('ELSE timestamp:', global.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
         }
 
     }
@@ -227,24 +227,24 @@ class Tweakers extends Homey.App {
 
             const url = 'https://tweakers.net/feeds/va.xml';
 
-            await this.log('Start GetTweakersVraagAanbod');
+            this.log('Start GetTweakersVraagAanbod');
 
             var items = await feedparser.parse(url);
-            var TweakersVraagAanbodTitel = await items[0].title;
-            var TweakersVraagAanbodDatumTZ = await items[0].date;
+            var TweakersVraagAanbodTitel = items[0].title;
+            var TweakersVraagAanbodDatumTZ = items[0].date;
             var TweakersVraagAanbodDatum = Date.parse(TweakersVraagAanbodDatumTZ) / 1000
-            await this.log('End Success GetTweakersVraagAanbod');
+            this.log('End Success GetTweakersVraagAanbod');
 
         } catch (error) {
             console.error('error: ', error)
-            await this.log('End Error GetTweakersVraagAanbod');
+            this.log('End Error GetTweakersVraagAanbod');
         }
 
         if (global.TweakersVraagAanbod !== TweakersVraagAanbodDatum) {
-            await this.log('IF timestamp:', global.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
+            this.log('IF timestamp:', global.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
             global.TweakersVraagAanbod = TweakersVraagAanbodDatum;
-            await console.log('IF titel:', TweakersVraagAanbodTitel);
-            await console.log('IF timestamp update:', global.TweakersVraagAanbod);
+            console.log('IF titel:', TweakersVraagAanbodTitel);
+            console.log('IF timestamp update:', global.TweakersVraagAanbod);
 
             //trigger flow
             let TriggerTweakersVraagAanbod = new Homey.FlowCardTrigger('TriggerTweakersVraagAanbod');
@@ -260,7 +260,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            await this.log('ELSE timestamp:', global.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
+            this.log('ELSE timestamp:', global.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
         }
 
     }

--- a/app.js
+++ b/app.js
@@ -9,12 +9,12 @@ class Tweakers extends Homey.App {
 
         this.log('Tweakers is gestart');
 
-        //Globale variablen
-        global.TweakersMixed;
-        global.TweakersNieuws;
-        global.TweakersMeukTracker;
-        global.TweakersGames;
-        global.TweakersVraagAanbod;
+        //App instantie variablen
+        this.TweakersMixed = null;
+	      this.TweakersNieuws = null;
+	      this.TweakersMeukTracker = null;
+	      this.TweakersGames = null;
+	      this.TweakersVraagAanbod = null;
 
         //Start loop interval
         this.log('StartInterval');
@@ -62,12 +62,12 @@ class Tweakers extends Homey.App {
             this.log('End Error GetTweakersMixed');
         }
 
-        if (global.TweakersMixed !== TweakersMixedDatum) {
-            this.log('IF timestamp:', global.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
-            global.TweakersMixed = TweakersMixedDatum;
+        if (this.TweakersMixed !== TweakersMixedDatum) {
+            this.log('IF timestamp:', this.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
+	        this.TweakersMixed = TweakersMixedDatum;
             console.log('IF titel:', TweakersMixedTitel);
             console.log('IF TweakersMixedCategorie:', TweakersMixedCategorie);
-            console.log('IF timestamp update:', global.TweakersMixed);
+            console.log('IF timestamp update:', this.TweakersMixed);
 
             //trigger flow
             let TriggerTweakersMixed = new Homey.FlowCardTrigger('TriggerTweakersMixed');
@@ -83,7 +83,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            this.log('ELSE timestamp:', global.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
+            this.log('ELSE timestamp:', this.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
         }
 
     }
@@ -108,11 +108,11 @@ class Tweakers extends Homey.App {
             this.log('End Error GetTweakersNieuws');
         }
 
-        if (global.TweakersNieuws !== TweakersNieuwsDatum) {
-            this.log('IF timestamp:', global.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
-            global.TweakersNieuws = TweakersNieuwsDatum;
+        if (this.TweakersNieuws !== TweakersNieuwsDatum) {
+            this.log('IF timestamp:', this.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
+	          this.TweakersNieuws = TweakersNieuwsDatum;
             console.log('IF titel:', TweakersNieuwsTitel);
-            console.log('IF timestamp update:', global.TweakersNieuws);
+            console.log('IF timestamp update:', this.TweakersNieuws);
 
             //trigger flow
             let TriggerTweakersNieuws = new Homey.FlowCardTrigger('TriggerTweakersNieuws');
@@ -128,7 +128,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            this.log('ELSE timestamp:', global.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
+            this.log('ELSE timestamp:', this.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
         }
 
     }
@@ -152,11 +152,11 @@ class Tweakers extends Homey.App {
             this.log('End Error GetTweakersMeukTracker');
         }
 
-        if (global.TweakersMeukTracker !== TweakersMeukDatum) {
-            this.log('IF timestamp:', global.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
-            global.TweakersMeukTracker = TweakersMeukDatum;
+        if (this.TweakersMeukTracker !== TweakersMeukDatum) {
+            this.log('IF timestamp:', this.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
+	          this.TweakersMeukTracker = TweakersMeukDatum;
             console.log('IF titel:', TweakersMeukTitel);
-            console.log('IF timestamp update:', global.TweakersMeukTracker);
+            console.log('IF timestamp update:', this.TweakersMeukTracker);
 
             //trigger flow
             let TriggerTweakersMeukTracker = new Homey.FlowCardTrigger('TriggerTweakersMeukTracker');
@@ -172,7 +172,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            this.log('ELSE timestamp:', global.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
+            this.log('ELSE timestamp:', this.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
         }
 
     }
@@ -196,11 +196,11 @@ class Tweakers extends Homey.App {
             this.log('End Error GetTweakersGames');
         }
 
-        if (global.TweakersGames !== TweakersGamesDatum) {
-            this.log('IF timestamp:', global.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
-            global.TweakersGames = TweakersGamesDatum;
+        if (this.TweakersGames !== TweakersGamesDatum) {
+            this.log('IF timestamp:', this.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
+	          this.TweakersGames = TweakersGamesDatum;
             console.log('IF titel:', TweakersGamesTitel);
-            console.log('IF timestamp update:', global.TweakersGames);
+            console.log('IF timestamp update:', this.TweakersGames);
 
             //trigger flow
             let TriggerTweakersGames = new Homey.FlowCardTrigger('TriggerTweakersGames');
@@ -216,7 +216,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            this.log('ELSE timestamp:', global.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
+            this.log('ELSE timestamp:', this.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
         }
 
     }
@@ -240,11 +240,11 @@ class Tweakers extends Homey.App {
             this.log('End Error GetTweakersVraagAanbod');
         }
 
-        if (global.TweakersVraagAanbod !== TweakersVraagAanbodDatum) {
-            this.log('IF timestamp:', global.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
-            global.TweakersVraagAanbod = TweakersVraagAanbodDatum;
+        if (this.TweakersVraagAanbod !== TweakersVraagAanbodDatum) {
+            this.log('IF timestamp:', this.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
+	          this.TweakersVraagAanbod = TweakersVraagAanbodDatum;
             console.log('IF titel:', TweakersVraagAanbodTitel);
-            console.log('IF timestamp update:', global.TweakersVraagAanbod);
+            console.log('IF timestamp update:', this.TweakersVraagAanbod);
 
             //trigger flow
             let TriggerTweakersVraagAanbod = new Homey.FlowCardTrigger('TriggerTweakersVraagAanbod');
@@ -260,7 +260,7 @@ class Tweakers extends Homey.App {
                 .then(this.log)
 
         } else {
-            this.log('ELSE timestamp:', global.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
+            this.log('ELSE timestamp:', this.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
         }
 
     }

--- a/app.js
+++ b/app.js
@@ -11,10 +11,22 @@ class Tweakers extends Homey.App {
 
         //App instantie variablen
         this.TweakersMixed = null;
-	      this.TweakersNieuws = null;
-	      this.TweakersMeukTracker = null;
-	      this.TweakersGames = null;
-	      this.TweakersVraagAanbod = null;
+        this.TweakersNieuws = null;
+        this.TweakersMeukTracker = null;
+        this.TweakersGames = null;
+        this.TweakersVraagAanbod = null;
+
+
+        this.TriggerTweakersMixed = new Homey.FlowCardTrigger('TriggerTweakersMixed')
+            .register();
+        this.TriggerTweakersNieuws = new Homey.FlowCardTrigger('TriggerTweakersNieuws')
+            .register();
+        this.TriggerTweakersMeukTracker = new Homey.FlowCardTrigger('TriggerTweakersMeukTracker')
+            .register();
+        this.TriggerTweakersGames = new Homey.FlowCardTrigger('TriggerTweakersGames')
+            .register();
+        this.TriggerTweakersVraagAanbod = new Homey.FlowCardTrigger('TriggerTweakersVraagAanbod')
+            .register();
 
         //Start loop interval
         this.log('StartInterval');
@@ -40,6 +52,8 @@ class Tweakers extends Homey.App {
         setInterval(() => {
             this.LoopTweakers();
         }, 300000); //5 minuten ->  300000
+        // Call this.loopTweakers() to set the initial state
+        this.LoopTweakers();
     }
 
     //Trigger TweakersMixed
@@ -64,20 +78,18 @@ class Tweakers extends Homey.App {
 
         if (this.TweakersMixed !== TweakersMixedDatum) {
             this.log('IF timestamp:', this.TweakersMixed + ' = ' + 'TweakersMixedDatum:', TweakersMixedDatum);
-	        this.TweakersMixed = TweakersMixedDatum;
+            this.TweakersMixed = TweakersMixedDatum;
             console.log('IF titel:', TweakersMixedTitel);
             console.log('IF TweakersMixedCategorie:', TweakersMixedCategorie);
             console.log('IF timestamp update:', this.TweakersMixed);
 
             //trigger flow
-            let TriggerTweakersMixed = new Homey.FlowCardTrigger('TriggerTweakersMixed');
 
             let tokens = {
                 'title': TweakersMixedTitel
             }
 
-            TriggerTweakersMixed
-                .register()
+            return this.TriggerTweakersMixed
                 .trigger(tokens)
                 .catch(this.error)
                 .then(this.log)
@@ -110,19 +122,17 @@ class Tweakers extends Homey.App {
 
         if (this.TweakersNieuws !== TweakersNieuwsDatum) {
             this.log('IF timestamp:', this.TweakersNieuws + ' = ' + 'TweakersNieuwsDatum:', TweakersNieuwsDatum);
-	          this.TweakersNieuws = TweakersNieuwsDatum;
+            this.TweakersNieuws = TweakersNieuwsDatum;
             console.log('IF titel:', TweakersNieuwsTitel);
             console.log('IF timestamp update:', this.TweakersNieuws);
 
             //trigger flow
-            let TriggerTweakersNieuws = new Homey.FlowCardTrigger('TriggerTweakersNieuws');
 
             let tokens = {
                 'title': TweakersNieuwsTitel
             }
 
-            TriggerTweakersNieuws
-                .register()
+            return this.TriggerTweakersNieuws
                 .trigger(tokens)
                 .catch(this.error)
                 .then(this.log)
@@ -154,19 +164,17 @@ class Tweakers extends Homey.App {
 
         if (this.TweakersMeukTracker !== TweakersMeukDatum) {
             this.log('IF timestamp:', this.TweakersMeukTracker + ' = ' + 'TweakersMeukDatum:', TweakersMeukDatum);
-	          this.TweakersMeukTracker = TweakersMeukDatum;
+            this.TweakersMeukTracker = TweakersMeukDatum;
             console.log('IF titel:', TweakersMeukTitel);
             console.log('IF timestamp update:', this.TweakersMeukTracker);
 
             //trigger flow
-            let TriggerTweakersMeukTracker = new Homey.FlowCardTrigger('TriggerTweakersMeukTracker');
 
             let tokens = {
                 'title': TweakersMeukTitel
             }
 
-            TriggerTweakersMeukTracker
-                .register()
+            return this.TriggerTweakersMeukTracker
                 .trigger(tokens)
                 .catch(this.error)
                 .then(this.log)
@@ -198,19 +206,17 @@ class Tweakers extends Homey.App {
 
         if (this.TweakersGames !== TweakersGamesDatum) {
             this.log('IF timestamp:', this.TweakersGames + ' = ' + 'TweakersGamesDatum:', TweakersGamesDatum);
-	          this.TweakersGames = TweakersGamesDatum;
+            this.TweakersGames = TweakersGamesDatum;
             console.log('IF titel:', TweakersGamesTitel);
             console.log('IF timestamp update:', this.TweakersGames);
 
             //trigger flow
-            let TriggerTweakersGames = new Homey.FlowCardTrigger('TriggerTweakersGames');
 
             let tokens = {
                 'title': TweakersGamesTitel
             }
 
-            TriggerTweakersGames
-                .register()
+            return this.TriggerTweakersGames
                 .trigger(tokens)
                 .catch(this.error)
                 .then(this.log)
@@ -242,19 +248,17 @@ class Tweakers extends Homey.App {
 
         if (this.TweakersVraagAanbod !== TweakersVraagAanbodDatum) {
             this.log('IF timestamp:', this.TweakersVraagAanbod + ' = ' + 'TweakersVraagAanbodDatum:', TweakersVraagAanbodDatum);
-	          this.TweakersVraagAanbod = TweakersVraagAanbodDatum;
+            this.TweakersVraagAanbod = TweakersVraagAanbodDatum;
             console.log('IF titel:', TweakersVraagAanbodTitel);
             console.log('IF timestamp update:', this.TweakersVraagAanbod);
 
             //trigger flow
-            let TriggerTweakersVraagAanbod = new Homey.FlowCardTrigger('TriggerTweakersVraagAanbod');
 
             let tokens = {
                 'title': TweakersVraagAanbodTitel
             }
 
-            TriggerTweakersVraagAanbod
-                .register()
+            return this.TriggerTweakersVraagAanbod
                 .trigger(tokens)
                 .catch(this.error)
                 .then(this.log)
@@ -264,7 +268,6 @@ class Tweakers extends Homey.App {
         }
 
     }
-
 
 
 }


### PR DESCRIPTION
Hi,

I was reviewing your app and saw some things that could be improved in your app. 
This pull request is meant to show some coding best practises and does not have to be merged if you want to keep your code how it is.

The changes I would like to propose are: 
Commit 1:
You only need to add await to a function call if it returns a promise.
If await is added to a function that returns undefined or something else the process will suspend for no reason.
Example: Although this `const test = await undefined; // ...` is valid code under the hood it will do something like this:
```
new Promise(function (resolve, reject){
    resolve(undefined);
}).then(function(result){
    const test = result;
    // ...
})
```

Commit 2:
Replaced global variables with class instance variables (on "this")
It is best practise to not use global variables in your application. The reason for this is that when a lot of global variables are used some problems arise.
For instance you could get naming collisions where for instance you store some string in global.url and your http request also uses global.url to store a different value you will get bugs and there would be no way to trace where it comes from.
The second problem is that if you do use global to access a variable somewhere else it is not transparent for you or another developer where this global variable is set and if it is even initialized.

Therefore it is much better to store the variables in the class instance. With Homey you get the added feature that you can access this variable anywhere since you can get the app instance on `Homey.app`. For instance to access TweakersMixed from some other file somewhere you could write `Homey.app.TweakersMixed` to get the value.

Commit 3:
Which is far more verbose than it needs to be and therefore is slower.
Moved Flow card registration to onInit function since you only need to create and register flow card instances once, after that you can call trigger as many times as you like on the same instance.

Changed the return of all Get methods to return the promise of the flow card trigger. This will cause the await in LoopTweakers() to also wait for the flow card to trigger before executing the next line of code.
Added a LoopTweakers() call to startLoop() to set the initial state on app startup (instead of waiting 5 minutes to get the initial state)

Regards,
Bas